### PR TITLE
Custom filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.3.0
 
-* Added a `filters` option, allowing custom filters to be added to the export dialog box.
+* Added a `filters` option, allowing custom filters to be added to the export dialog box. Thanks to Michelin for making this work possible via Apostrophe Enterprise Support.
 
 ### 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.3.0
+
+* Added a `filters` option, allowing custom filters to be added to the export dialog box.
+
 ### 2.2.0
 
 * Added the `exportAsPlaintext: true` option, which can be set on any `area` or `singleton` schema field to export just the plaintext, rather than the markup.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ modules: {
 
 Just click the "export" button in the "manage" view of your pieces. A progress display will appear. Once the export has completed, you will be instructed to click "Done," at which point the file will be downloaded. **For space and security reasons, export files expire after one hour,** so keep this in mind if you walk away from the export process.
 
+## Adding filters to the export dialog box
+
+The export dialog box has basic support for custom filters. You may add them like this:
+
+```javascript
+  'my-module-that-extends-pieces': {
+    export: {
+      filters: {
+        // Filter on the standard `tags` schema field
+        name: 'tags',
+        label: 'Tags'
+      }
+    }
+  }
+```
+
+The basic rule is that **if a field supports being used as a filter in the "Manage" view of pieces, it will work here too.** Most field types will work. However, multiple select is not currently supported. We do not recommend the use of this feature if the number of choices is very large (more than 100). Bear in mind that users can also filter data later in their spreadsheet or database of choice.
+
 ## Extending the export process for your piece type
 
 The exporter relies on a simple conversion from each standard field type to a string. That conversion works well for the same field types that import well with `apostrophe-pieces-importer`.

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = {
                 newFilter.choices = [
                   {
                     value: '',
-                    label: 'CHOOSE ONE'
+                    label: 'Choose One'
                   }
                 ].concat(choices);
                 data.filters.push(newFilter);

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = {
       self.exportAddRoutes = function () {
         self.route('post', 'export-modal', function (req, res) {
           const data = {
-              options: {
+            options: {
               label: self.label,
               pluralLabel: self.pluralLabel,
               name: self.name
@@ -103,7 +103,7 @@ module.exports = {
               });
             }, callback);
           }
-         });
+        });
 
         self.route('post', 'export', function (req, res) {
           let draftOrLive = self.apos.launder.string(req.body.draftOrLive);

--- a/index.js
+++ b/index.js
@@ -65,20 +65,56 @@ module.exports = {
 
       self.exportAddRoutes = function () {
         self.route('post', 'export-modal', function (req, res) {
-          return res.send(self.render(req, 'exportModal', {
-            options: {
+          const data = {
+              options: {
               label: self.label,
               pluralLabel: self.pluralLabel,
               name: self.name
             },
             exportFormats: self.exportFormats
-          }));
-        });
+          };
+          return async.series([ exportFilters ], function(err) {
+            if (err) {
+              self.apos.utils.error(err);
+              return res.status(500).send('error');
+            }
+            return res.send(self.render(req, 'exportModal', data));
+          });
+
+          function exportFilters(callback) {
+            if (!self.options.export.filters) {
+              return callback(null);
+            }
+            data.filters = [];
+            return async.eachSeries(self.options.export.filters, function(filter, callback) {
+              var newFilter = {
+                name: filter.name,
+                label: filter.label
+              };
+              return self.find(req).toChoices(filter.name, function(err, choices) {
+                newFilter.choices = [
+                  {
+                    value: '',
+                    label: 'CHOOSE ONE'
+                  }
+                ].concat(choices);
+                data.filters.push(newFilter);
+                return callback(err);
+              });
+            }, callback);
+          }
+         });
 
         self.route('post', 'export', function (req, res) {
           let draftOrLive = self.apos.launder.string(req.body.draftOrLive);
           let published = self.apos.launder.string(req.body.published);
           let extension = self.apos.launder.string(req.body.extension);
+          const filters = {};
+          _.each(self.options.export.filters || [], function(filter) {
+            if (_.has(req.body, filter.name)) {
+              filters[filter.name] = self.apos.launder.string(req.body[filter.name]);
+            }
+          });
           if (!self.exportFormats[extension]) {
             return res.send({ status: 'invalid' });
           }
@@ -90,7 +126,8 @@ module.exports = {
                 draftOrLive: draftOrLive,
                 published: published,
                 extension: extension,
-                format: format
+                format: format,
+                filters: filters
               }, callback);
             },
             {
@@ -196,7 +233,7 @@ module.exports = {
           return {};
 
           function nextBatch (callback) {
-            return self.find(req).published(published).sort({ _id: 1 }).and({ _id: { $gt: lastId } }).limit(options.batchSize || 100).toArray(function (err, batch) {
+            return self.find(req).published(published).sort({ _id: 1 }).and({ _id: { $gt: lastId } }).limit(options.batchSize || 100).queryToFilters(options.filters || {}, 'manage').toArray(function (err, batch) {
               if (err) {
                 return callback(err);
               }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-standard": "^3.0.1",
-    "mocha": "^5.0.0",
+    "mocha": "^7.0.0",
     "request": "^2.88.0"
   },
   "dependencies": {

--- a/public/js/export-modal.js
+++ b/public/js/export-modal.js
@@ -15,11 +15,19 @@ apos.define('apostrophe-pieces-export-modal', {
         var draftOrLive = self.$el.find('[name="draft-or-live"]').val();
         var published = self.$el.find('[name="published"]').val();
         var extension = self.$el.find('[name="extension"]').val();
-        self.api('export', {
+        var data = {
           draftOrLive: draftOrLive,
           published: published,
           extension: extension
-        }, function (result) {
+        };
+        var $selects = self.$el.find('.apos-pieces-export-filter select');
+        $selects.each(function() {
+          var $select = $(this);
+          if ($select.val().length) {
+            data[$select.attr('name')] = $select.val();
+          }
+        });
+        self.api('export', data, function (result) {
           if (result.status !== 'ok') {
             apos.notify(result.status, { type: 'error' });
             return;

--- a/views/exportModal.html
+++ b/views/exportModal.html
@@ -1,5 +1,6 @@
 {%- extends "apostrophe-modal:baseSlideable.html" -%}
 {%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
+{%- import 'apostrophe-ui:components/fields.html' as fields with context -%}
 
 {%- block modalClass -%}
   apos-pieces-export {{ data.options.name | css }}-import apos-ui-modal-no-sidebar apos-modal-slideable
@@ -41,6 +42,18 @@
           {%- endfor -%}
         </select>
       </fieldset>
+      {%- if data.filters -%}
+        {%- for filter in data.filters -%}
+          <fieldset class="apos-pieces-export-filter">
+            <label>{{ __(filter.label) }}</label>
+            <select name="{{ filter.name }}">
+              {% for choice in filter.choices %}
+                <option {{ 'checked' if loop.first }} value="{{ choice.value }}">{{ choice.label }}</option>
+              {% endfor %}
+            </select>
+          </fieldset>
+        {%- endfor -%}
+      {%- endif -%}
       {{ buttons.major('Export All', { action: 'export' }, 'apos-button--major apos-pieces-export-submit') }}
     </form>
   </div>


### PR DESCRIPTION
See changelog and README. Yes it would be nice to support export being a regular "batch action," but that would require a lot of new code to allow access to the manage modal in live mode, and a decision was made by the team many moons ago not to go there. So instead to meet a new client need (DGAD) we're adding a little bit more filtering support within the export modal, and it's actually pretty nice.

Also addressed security alerts caused by old mocha version.