### PR TITLE
Updates versions for Github warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.3.1
+
+* Updates lodash and ApostropheCMS dependencies to resolve lodash and node-fetch vulnerability warnings.
+
 ### 2.3.0
 
 * Added a `filters` option, allowing custom filters to be added to the export dialog box. Thanks to Michelin for making this work possible via Apostrophe Enterprise Support.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-pieces-export",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Export pieces for ApostropheCMS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/apostrophecms/apostrophe-pieces-export#readme",
   "devDependencies": {
-    "apostrophe": "^2.72.1",
+    "apostrophe": "^2.112.1",
     "eslint": "^4.2.0",
     "eslint-config-apostrophe": "^2.0.2",
     "eslint-config-standard": "^10.2.1",
@@ -37,7 +37,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "csv-stringify": "^5.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.19",
     "xlsx": "^0.14.1"
   }
 }


### PR DESCRIPTION
This should resolve the lodash and node-fetch vulnerability warnings.